### PR TITLE
Fix `runBefore` edge case that can mis-sort options

### DIFF
--- a/src/csscomb.js
+++ b/src/csscomb.js
@@ -15,11 +15,10 @@ let CSScomb = function(config) {
   let comb = new Comb();
 
   // Add plugins.
-  fs.readdirSync(__dirname + '/options').map(function(option) {
+  let options = fs.readdirSync(__dirname + '/options').map(function (option) {
     return require('./options/' + option);
-  }).forEach(function(option) {
-    comb.use(option);
   });
+  comb.use(options);
 
   // If config was passed, configure:
   if (typeof config === 'string') {


### PR DESCRIPTION
In a chain of `runBefore` properties, it's possible to end up with options out of order. This approach guarantees options will always be sorted properly, but may crash if there is a cyclic dependency.